### PR TITLE
Added support of escape characters

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,7 +210,7 @@ func main() {
 		// encrypt or decrypt
 		if *args.EncryptMode {
 			// init hacky bar
-			bar = out.CreateHackyBar(args.Encoder, len(exploit.Pkcs7Pad(input, bl))+bl, *args.EncryptMode, print)
+			bar = out.CreateHackyBar(args.Encoder, len(exploit.Pkcs7Pad(exploit.ApplyEscapeCharacters(input), bl))+bl, *args.EncryptMode, print)
 
 			// provide HTTP client with event-channel, so we can count RPS
 			client.RequestEventChan = bar.ChanReq

--- a/pkg/exploit/encrypt.go
+++ b/pkg/exploit/encrypt.go
@@ -1,13 +1,75 @@
 package exploit
 
 import (
+	"encoding/hex"
+	"errors"
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/glebarez/padre/pkg/util"
 )
 
+func charMap(str string) (string, error) {
+	chars := map[string]string{
+		"n": "0a",
+		"t": "09",
+		"r": "0d",
+		"f": "0c",
+		"b": "08",
+	}
+	char := ""
+	if len(str) == 1 {
+		ch, ok := chars[str]
+		if !ok {
+			return "", errors.New("invalid escape character: " + str)
+		}
+		char = ch
+	} else {
+		char = str
+	}
+
+	strBytes, err := hex.DecodeString(char)
+	if err != nil {
+		return "", err
+	}
+
+	return string(strBytes), nil
+}
+
+func applyEscapeCharactersBySegment(str string) string {
+	// match things like \x00 and \n \t etc
+	re := regexp.MustCompile(`(?m)\\x([0-9a-f][0-9a-f])|\\([ntrfb])`)
+
+	for _, match := range re.FindAllStringSubmatch(str, -1) {
+		char := match[1]
+		if char == "" {
+			char = match[2]
+		}
+		replacementChar, err := charMap(char)
+		if err == nil {
+			str = strings.Replace(str, match[0], replacementChar, 1)
+		}
+	}
+
+	return str
+}
+
+func ApplyEscapeCharacters(str string) string {
+	// temporarily remove "\\" since it would interfere with parsing characters like \n or \x00
+	segments := strings.Split(str, "\\\\")
+	parsedSegments := []string{}
+	for _, segment := range segments {
+		parsedSegments = append(parsedSegments, applyEscapeCharactersBySegment(segment))
+	}
+	str = strings.Join(parsedSegments, "\\")
+	return str
+}
+
 func (p *Padre) Encrypt(plainText string, byteStream chan byte) ([]byte, error) {
 	blockLen := p.BlockLen
+
+	plainText = ApplyEscapeCharacters(plainText)
 
 	// pad
 	plainText = Pkcs7Pad(plainText, blockLen)

--- a/usage.go
+++ b/usage.go
@@ -64,6 +64,7 @@ bold(Examples:)
 	POST data: cmd(padre -u "http://vulnerable.com/login" -post "token=$" "u7bvLewln6PJ670Gnj3hnE40L0SqG8e6")
 	Cookies: cmd(padre -u "http://vulnerable.com/login$" -cookie "auth=$" "u7bvLewln6PJ670Gnj3hnE40L0SqG8e6")
 	Encrypt token in GET parameter:	cmd(padre -u "http://vulnerable.com/login?token=$" -enc "EncryptMe")
+	Encrypt token in GET parameter with escape characters:	cmd(padre -u "http://vulnerable.com/login?token=$" -enc "Encrypt\r\n\xffM\te")
 `
 
 func init() {


### PR DESCRIPTION
Added functionality to support escape characters when forging ciphertext.
\\\\ -> \\
\n -> newline
\t -> tab
\r -> carriage return
...etc
\x00 -> HEX<00> (nullbyte)
\x01 -> HEX<01>
...etc

example:
`padre -u "http://vulnerable.com/login?token=$" -enc "Encrypt\r\n\xffM\te"`